### PR TITLE
Fixed pagination leaving out elements

### DIFF
--- a/lib/json_table.dart
+++ b/lib/json_table.dart
@@ -58,7 +58,7 @@ class _JsonTableState extends State<JsonTable> {
     if (_showPagination())
       paginationRowCount =
           math.min<int>(widget.paginationRowCount, data.length);
-    if (_showPagination()) pagesCount = data.length ~/ paginationRowCount;
+    if (_showPagination()) pagesCount = (data.length / paginationRowCount).ceil();
     setHeaderList();
   }
 


### PR DESCRIPTION
This PR fixes the issue where pagination leaves elements that remain after putting `PaginationRowCount*pages`